### PR TITLE
fix: multiple metrics should be separated with newline char

### DIFF
--- a/PVE/Status/Graphite.pm
+++ b/PVE/Status/Graphite.pm
@@ -102,7 +102,7 @@ sub write_graphite {
             if ( ref $value eq 'HASH' ) {
                 write_graphite($carbon_socket, $value, $ctime, $path);
             }else {
-                $carbon_socket->send( "$path $value $ctime" );
+                $carbon_socket->send( "$path $value $ctime\n" );
             }
         }
         $path = $oldpath;


### PR DESCRIPTION
Hello,

Carbon (particularly carbon-c-relay) expects one metric per line. Current PVE implementation breaks this rule. The following patch corrects this bug