### PR TITLE
rename env variable "tarfile" to "target"

### DIFF
--- a/vzdump-hook-script.pl
+++ b/vzdump-hook-script.pl
@@ -39,17 +39,17 @@ if ($phase eq 'job-start' ||
 
     my $hostname = $ENV{HOSTNAME};
 
-    # tarfile is only available in phase 'backup-end'
-    my $tarfile = $ENV{TARFILE};
+    # target is only available in phase 'backup-end'
+    my $target = $ENV{TARGET};
 
     # logfile is only available in phase 'log-end'
     my $logfile = $ENV{LOGFILE}; 
 
-    print "HOOK-ENV: vmtype=$vmtype;dumpdir=$dumpdir;storeid=$storeid;hostname=$hostname;tarfile=$tarfile;logfile=$logfile\n";
+    print "HOOK-ENV: vmtype=$vmtype;dumpdir=$dumpdir;storeid=$storeid;hostname=$hostname;target=$target;logfile=$logfile\n";
 
     # example: copy resulting backup file to another host using scp
     if ($phase eq 'backup-end') {
-    	#system ("scp $tarfile backup-host:/backup-dir") == 0 ||
+    	#system ("scp $target backup-host:/backup-dir") == 0 ||
     	#    die "copy tar file to backup-host failed";
     }
 


### PR DESCRIPTION
INFO: Use of uninitialized value $tarfile in concatenation (.) or string at /root/vzdump-hook-script.pl line 48.

I displayed all the available variables, I notice that "tarfile" is now "target"